### PR TITLE
Add support for translucent and clear colors.

### DIFF
--- a/Source/UIColor+Hex.swift
+++ b/Source/UIColor+Hex.swift
@@ -6,7 +6,6 @@ extension UIColor {
      - parameter hex: The base HEX string to create the color.
      */
     public convenience init(hex: String) {
-        let clearKeyword = "CLEAR"
         let noHashString = hex.stringByReplacingOccurrencesOfString("#", withString: "")
         let scanner = NSScanner(string: noHashString)
         scanner.charactersToBeSkipped = NSCharacterSet.symbolCharacterSet()
@@ -21,9 +20,7 @@ extension UIColor {
         }
 
         var hexInt: UInt32 = 0
-        if (noHashString == clearKeyword) {
-            self.init(white: 0, alpha: 0)
-        } else if (scanner.scanHexInt(&hexInt)) {
+        if (scanner.scanHexInt(&hexInt)) {
             let red = (hexInt >> 16) & 0xFF
             let green = (hexInt >> 8) & 0xFF
             let blue = (hexInt) & 0xFF

--- a/Source/UIColor+Hex.swift
+++ b/Source/UIColor+Hex.swift
@@ -6,17 +6,29 @@ extension UIColor {
      - parameter hex: The base HEX string to create the color.
      */
     public convenience init(hex: String) {
-        let noHasString = hex.stringByReplacingOccurrencesOfString("#", withString: "")
-        let scanner = NSScanner(string: noHasString)
+        let clearKeyword = "CLEAR"
+        let noHashString = hex.stringByReplacingOccurrencesOfString("#", withString: "")
+        let scanner = NSScanner(string: noHashString)
         scanner.charactersToBeSkipped = NSCharacterSet.symbolCharacterSet()
+        
+        var alpha:CGFloat = 1.0
+        if noHashString.characters.count > 6 {
+            let startIndex = noHashString.endIndex.advancedBy(-2)
+            let alphaString = noHashString.substringFromIndex(startIndex)
+            if let value = NSNumberFormatter().numberFromString(alphaString) {
+                alpha = CGFloat(Float(value) * 0.01)
+            }
+        }
 
         var hexInt: UInt32 = 0
-        if (scanner.scanHexInt(&hexInt)) {
+        if (noHashString == clearKeyword) {
+            self.init(white: 0, alpha: 0)
+        } else if (scanner.scanHexInt(&hexInt)) {
             let red = (hexInt >> 16) & 0xFF
             let green = (hexInt >> 8) & 0xFF
             let blue = (hexInt) & 0xFF
 
-            self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
+            self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: alpha)
         } else {
             self.init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
         }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -22,4 +22,18 @@ class Tests: XCTestCase {
 
         XCTAssertFalse(whiteHex.isEqualToColor(black))
     }
+    
+    func testTranslucentRedColor() {
+        let redHex = UIColor(hex: "#ff000050")
+        let red = UIColor.redColor().colorWithAlphaComponent(0.5)
+
+        XCTAssertTrue(redHex.isEqualToColor(red))
+    }
+
+    func testClearColor() {
+        let clearHex = UIColor(hex: "CLEAR")
+        let clear = UIColor.clearColor()
+
+        XCTAssertTrue(clearHex.isEqualToColor(clear))
+    }
 }


### PR DESCRIPTION
### Usage

An 8 character hex value is broken down into the following parts: `{2} RED {2} GREEN {2} BLUE {2} ALPHA`. Passing a value from `00` to `99` as the last set results in a change in the alpha property. Leaving off the last set defaults to an alpha value of `1.0`.

Passing `CLEAR` as the hex value results in a true clear color instance of UIColor.
### Examples

`UIColor(hex: "#ff0000")` `=>` `UIColor.redColor()`
`UIColor(hex: "#ff000050")` `=>` `UIColor.redColor().colorWithAlphaComponent(0.50)`
`UIColor(hex: "#ff000075")` `=>` `UIColor.redColor().colorWithAlphaComponent(0.75)`
`UIColor(hex: "CLEAR")` `=>` `UIColor.clearColor()`
