### PR TITLE
fix: swift4 compile error

### DIFF
--- a/Source/UIColor+Hex.swift
+++ b/Source/UIColor+Hex.swift
@@ -49,10 +49,12 @@ public extension UIColor {
 
     /// Get the red, green, blue and alpha values.
     private var RGBA: [CGFloat] {
-        var RGBA: [CGFloat] = [0,0,0,0]
-        self.getRed(&RGBA[0], green: &RGBA[1], blue: &RGBA[2], alpha: &RGBA[3])
-
-        return RGBA
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return [r, g, b, a]
     }
 
     private func compareColorComponents(a: CGFloat, b: CGFloat) -> Bool {


### PR DESCRIPTION
Compiling with swift 4.0 on the Xcode 9 GM seed throws the following error
```
Overlapping accesses to 'RGBA', but modification requires exclusive access;
consider copying to a local variable
```