### PR TITLE
OS X support

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -12,6 +12,11 @@
 		14DEED4B1F95497200A537FB /* Hex.h in Headers */ = {isa = PBXBuildFile; fileRef = 147DA2171F9548EB00CCDA49 /* Hex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14DEED4C1F95497400A537FB /* UIColor+Hex.swift in Headers */ = {isa = PBXBuildFile; fileRef = 1424E4391BDE2F6C00E79490 /* UIColor+Hex.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		14DEED4D1F9549AD00A537FB /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A139B31AEFC72B00AD732F /* Tests.swift */; };
+		9932848A2306A9EE00B8F0C0 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1424E4391BDE2F6C00E79490 /* UIColor+Hex.swift */; };
+		9932848D2306A9EE00B8F0C0 /* Hex.h in Headers */ = {isa = PBXBuildFile; fileRef = 147DA2171F9548EB00CCDA49 /* Hex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9932848E2306A9EE00B8F0C0 /* UIColor+Hex.swift in Headers */ = {isa = PBXBuildFile; fileRef = 1424E4391BDE2F6C00E79490 /* UIColor+Hex.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		993284992306AA1000B8F0C0 /* Hex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 147DA20D1F95488B00CCDA49 /* Hex.framework */; };
+		993284A12306AA6700B8F0C0 /* Tests OS X.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993284A02306AA6700B8F0C0 /* Tests OS X.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +30,12 @@
 		14C0AF811BD6D4230009ECBE /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		14C0AF821BD6D4230009ECBE /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		14C0AF831BD6D4230009ECBE /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		993284872306A97000B8F0C0 /* Hex-iOS copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Hex-iOS copy-Info.plist"; path = "/Users/voxar/Work/Code/Hex/Hex-iOS copy-Info.plist"; sourceTree = "<absolute>"; };
+		993284932306A9EE00B8F0C0 /* Hex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Hex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		993284942306A9EE00B8F0C0 /* Hex-iOS copy2-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Hex-iOS copy2-Info.plist"; path = "/Users/voxar/Work/Code/Hex/Hex-iOS copy2-Info.plist"; sourceTree = "<absolute>"; };
+		9932849E2306AA1000B8F0C0 /* Tests OS X.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests OS X.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9932849F2306AA1000B8F0C0 /* Tests copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Tests copy-Info.plist"; path = "/Users/voxar/Work/Code/Hex/Tests copy-Info.plist"; sourceTree = "<absolute>"; };
+		993284A02306AA6700B8F0C0 /* Tests OS X.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tests OS X.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -43,6 +54,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9932848B2306A9EE00B8F0C0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		993284982306AA1000B8F0C0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				993284992306AA1000B8F0C0 /* Hex.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -54,6 +80,9 @@
 				146D72AF1AB782920058798C /* Tests */,
 				146D72941AB782920058798C /* Products */,
 				147DA2191F95492B00CCDA49 /* Frameworks */,
+				993284872306A97000B8F0C0 /* Hex-iOS copy-Info.plist */,
+				993284942306A9EE00B8F0C0 /* Hex-iOS copy2-Info.plist */,
+				9932849F2306AA1000B8F0C0 /* Tests copy-Info.plist */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
@@ -64,6 +93,8 @@
 			children = (
 				146D72AC1AB782920058798C /* Tests.xctest */,
 				147DA20D1F95488B00CCDA49 /* Hex.framework */,
+				993284932306A9EE00B8F0C0 /* Hex.framework */,
+				9932849E2306AA1000B8F0C0 /* Tests OS X.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -72,6 +103,7 @@
 			isa = PBXGroup;
 			children = (
 				14A139B31AEFC72B00AD732F /* Tests.swift */,
+				993284A02306AA6700B8F0C0 /* Tests OS X.swift */,
 				146D72B01AB782920058798C /* Supporting Files */,
 			);
 			path = Tests;
@@ -124,6 +156,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9932848C2306A9EE00B8F0C0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9932848D2306A9EE00B8F0C0 /* Hex.h in Headers */,
+				9932848E2306A9EE00B8F0C0 /* UIColor+Hex.swift in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -162,6 +203,41 @@
 			productReference = 147DA20D1F95488B00CCDA49 /* Hex.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		993284882306A9EE00B8F0C0 /* Hex-OS X */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 993284902306A9EE00B8F0C0 /* Build configuration list for PBXNativeTarget "Hex-OS X" */;
+			buildPhases = (
+				993284892306A9EE00B8F0C0 /* Sources */,
+				9932848B2306A9EE00B8F0C0 /* Frameworks */,
+				9932848C2306A9EE00B8F0C0 /* Headers */,
+				9932848F2306A9EE00B8F0C0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Hex-OS X";
+			productName = "Hex-iOS";
+			productReference = 993284932306A9EE00B8F0C0 /* Hex.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		993284952306AA1000B8F0C0 /* Tests OS X */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9932849B2306AA1000B8F0C0 /* Build configuration list for PBXNativeTarget "Tests OS X" */;
+			buildPhases = (
+				993284962306AA1000B8F0C0 /* Sources */,
+				993284982306AA1000B8F0C0 /* Frameworks */,
+				9932849A2306AA1000B8F0C0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Tests OS X";
+			productName = PodTests;
+			productReference = 9932849E2306AA1000B8F0C0 /* Tests OS X.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -182,6 +258,9 @@
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
+					993284882306A9EE00B8F0C0 = {
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 146D728E1AB782920058798C /* Build configuration list for PBXProject "Demo" */;
@@ -189,6 +268,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -199,6 +279,8 @@
 			targets = (
 				146D72AB1AB782920058798C /* Tests */,
 				147DA20C1F95488B00CCDA49 /* Hex-iOS */,
+				993284882306A9EE00B8F0C0 /* Hex-OS X */,
+				993284952306AA1000B8F0C0 /* Tests OS X */,
 			);
 		};
 /* End PBXProject section */
@@ -212,6 +294,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		147DA20B1F95488B00CCDA49 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9932848F2306A9EE00B8F0C0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9932849A2306AA1000B8F0C0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -234,6 +330,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				14DEED491F95496A00A537FB /* UIColor+Hex.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		993284892306A9EE00B8F0C0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9932848A2306A9EE00B8F0C0 /* UIColor+Hex.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		993284962306AA1000B8F0C0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				993284A12306AA6700B8F0C0 /* Tests OS X.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -358,6 +470,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sample.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -373,6 +486,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sample.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 			};
@@ -442,6 +556,110 @@
 			};
 			name = Release;
 		};
+		993284912306A9EE00B8F0C0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Hex-iOS copy2-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = net.3lvis.hex;
+				PRODUCT_NAME = Hex;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		993284922306A9EE00B8F0C0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Hex-iOS copy2-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = net.3lvis.hex;
+				PRODUCT_NAME = Hex;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9932849C2306AA1000B8F0C0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Tests copy-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sample.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		9932849D2306AA1000B8F0C0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "Tests copy-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sample.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -468,6 +686,24 @@
 			buildConfigurations = (
 				147DA2121F95488B00CCDA49 /* Debug */,
 				147DA2131F95488B00CCDA49 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		993284902306A9EE00B8F0C0 /* Build configuration list for PBXNativeTarget "Hex-OS X" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				993284912306A9EE00B8F0C0 /* Debug */,
+				993284922306A9EE00B8F0C0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9932849B2306AA1000B8F0C0 /* Build configuration list for PBXNativeTarget "Tests OS X" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9932849C2306AA1000B8F0C0 /* Debug */,
+				9932849D2306AA1000B8F0C0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Demo.xcodeproj/xcshareddata/xcschemes/Hex-OS X.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/Hex-OS X.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "147DA20C1F95488B00CCDA49"
-               BuildableName = "Hex.framework"
-               BlueprintName = "Hex-iOS"
+               BlueprintIdentifier = "993284882306A9EE00B8F0C0"
+               BuildableName = "Hex-OS X.framework"
+               BlueprintName = "Hex-OS X"
                ReferencedContainer = "container:Demo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +32,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "146D72AB1AB782920058798C"
-               BuildableName = "Tests.xctest"
-               BlueprintName = "Tests"
+               BlueprintIdentifier = "993284952306AA1000B8F0C0"
+               BuildableName = "Tests OS X.xctest"
+               BlueprintName = "Tests OS X"
                ReferencedContainer = "container:Demo.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -42,9 +42,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "147DA20C1F95488B00CCDA49"
-            BuildableName = "Hex.framework"
-            BlueprintName = "Hex-iOS"
+            BlueprintIdentifier = "993284882306A9EE00B8F0C0"
+            BuildableName = "Hex-OS X.framework"
+            BlueprintName = "Hex-OS X"
             ReferencedContainer = "container:Demo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -64,9 +64,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "147DA20C1F95488B00CCDA49"
-            BuildableName = "Hex.framework"
-            BlueprintName = "Hex-iOS"
+            BlueprintIdentifier = "993284882306A9EE00B8F0C0"
+            BuildableName = "Hex-OS X.framework"
+            BlueprintName = "Hex-OS X"
             ReferencedContainer = "container:Demo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -82,9 +82,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "147DA20C1F95488B00CCDA49"
-            BuildableName = "Hex.framework"
-            BlueprintName = "Hex-iOS"
+            BlueprintIdentifier = "993284882306A9EE00B8F0C0"
+            BuildableName = "Hex-OS X.framework"
+            BlueprintName = "Hex-OS X"
             ReferencedContainer = "container:Demo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Demo.xcodeproj/xcshareddata/xcschemes/Tests OS X.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/Tests OS X.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "993284952306AA1000B8F0C0"
+               BuildableName = "Tests OS X.xctest"
+               BlueprintName = "Tests OS X"
+               ReferencedContainer = "container:Demo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Hex-iOS copy-Info.plist
+++ b/Hex-iOS copy-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Hex-iOS copy2-Info.plist
+++ b/Hex-iOS copy2-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Hex.podspec
+++ b/Hex.podspec
@@ -12,16 +12,15 @@ Pod::Spec.new do |s|
   }
   s.author = { "Elvis Nuñez" => "elvisnunez@me.com" }
   s.social_media_url = "http://twitter.com/3lvis"
-  s.platform = :ios, '8.0'
   s.ios.deployment_target = '8.0'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
+  s.osx.deployment_target = '10.11'
 
   s.source = {
     :git => 'https://github.com/3lvis/Hex.git',
     :tag => s.version.to_s
   }
   s.source_files = 'Source'
-  s.frameworks = 'UIKit'
   s.requires_arc = true
 end

--- a/Source/Hex.h
+++ b/Source/Hex.h
@@ -1,4 +1,4 @@
-@import UIKit;
+@import Foundation;
 
 FOUNDATION_EXPORT double HexVersionNumber;
 FOUNDATION_EXPORT const unsigned char HexVersionString[];

--- a/Source/UIColor+Hex.swift
+++ b/Source/UIColor+Hex.swift
@@ -1,7 +1,13 @@
+#if os(OSX)
+import Cocoa
+public typealias NSUIColor = NSColor
+#else
 import UIKit
+public typealias NSUIColor = NSColor
+#endif
 
-public extension UIColor {
-    /// Base initializer, it creates an instance of `UIColor` using an HEX string.
+public extension NSUIColor {
+    /// Base initializer, it creates an instance of `NSUIColor` using an HEX string.
     ///
     /// - Parameter hex: The base HEX string to create the color.
     convenience init(hex: String) {
@@ -34,9 +40,9 @@ public extension UIColor {
 
     /// Compares if two colors are equal.
     ///
-    /// - Parameter color: A UIColor to compare.
+    /// - Parameter color: A NSUIColor to compare.
     /// - Returns: A boolean, true if same (or very similar) and false otherwise.
-    func isEqual(to color: UIColor) -> Bool {
+    func isEqual(to color: NSUIColor) -> Bool {
         let currentRGBA = self.RGBA
         let comparedRGBA = color.RGBA
 

--- a/Source/UIColor+Hex.swift
+++ b/Source/UIColor+Hex.swift
@@ -54,12 +54,31 @@ public extension NSUIColor {
 
 
     /// Get the red, green, blue and alpha values.
-    private var RGBA: [CGFloat] {
+    /// NOTE: This does not work for every color space,
+    /// if the color space is not convertible to RGB then [0,0,0,0] will be returned
+    internal var RGBA: [CGFloat] {
         var r: CGFloat = 0
         var g: CGFloat = 0
         var b: CGFloat = 0
         var a: CGFloat = 0
+        
+        
+        #if os(OSX)
+        if self.colorSpace != NSColorSpace.sRGB {
+            // try to convert to RGB
+            if let color = self.usingColorSpace(.sRGB) {
+                color.getRed(&r, green: &g, blue: &b, alpha: &a)
+            } else {
+                // try anyway and possibly crash
+                self.getRed(&r, green: &g, blue: &b, alpha: &a)
+            }
+        } else {
+            self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        }
+        #else
         self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        #endif
+        
         return [r, g, b, a]
     }
 

--- a/Source/UIColor+Hex.swift
+++ b/Source/UIColor+Hex.swift
@@ -3,7 +3,7 @@ import Cocoa
 public typealias NSUIColor = NSColor
 #else
 import UIKit
-public typealias NSUIColor = NSColor
+public typealias NSUIColor = UIColor
 #endif
 
 public extension NSUIColor {

--- a/Tests copy-Info.plist
+++ b/Tests copy-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Tests/Tests OS X.swift
+++ b/Tests/Tests OS X.swift
@@ -1,6 +1,6 @@
 import Cocoa
 import XCTest
-import Hex
+@testable import Hex
 
 class Tests: XCTestCase {
     func testBlackColor() {
@@ -42,5 +42,15 @@ class Tests: XCTestCase {
         XCTAssertTrue(NSColor(r: 0, g: 0, b: 0).isEqual(to: NSColor.black))
         XCTAssertTrue(NSColor(r: 255, g: 255, b: 255).isEqual(to: NSColor.white))
         XCTAssertTrue(NSColor(r: 0, g: 0, b: 0, a: 50).isEqual(to: NSColor.black.withAlphaComponent(0.5)))
+    }
+    
+    func testRGBA() {
+        let color = NSColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 0.4)
+        let rgba = color.RGBA
+        
+        XCTAssertEqual(rgba[0], 0.1, accuracy: 0.01)
+        XCTAssertEqual(rgba[1], 0.2, accuracy: 0.01)
+        XCTAssertEqual(rgba[2], 0.3, accuracy: 0.01)
+        XCTAssertEqual(rgba[3], 0.4, accuracy: 0.01)
     }
 }

--- a/Tests/Tests OS X.swift
+++ b/Tests/Tests OS X.swift
@@ -1,0 +1,46 @@
+import Cocoa
+import XCTest
+import Hex
+
+class Tests: XCTestCase {
+    func testBlackColor() {
+        let blackHex = NSColor(hex: "000000")
+        let black = NSColor.black
+
+        XCTAssertTrue(blackHex.isEqual(to: black))
+    }
+
+    func testRedColor() {
+        let redHex = NSColor(hex: "#ff0000")
+        let red = NSColor.red
+
+        XCTAssertTrue(redHex.isEqual(to: red))
+    }
+
+    func testHexYellowAndiOSYellow() {
+        let yellowHex = NSColor(hex: "#ffff00")
+        let yellowiOS = NSColor.yellow
+
+        XCTAssertTrue(yellowHex.isEqual(to: yellowiOS))
+    }
+
+    func testBlackAndWhiteColor() {
+        let whiteHex = NSColor(hex: "FFFFFF")
+        let black = NSColor.black
+
+        XCTAssertFalse(whiteHex.isEqual(to: black))
+    }
+
+    func testClearColor() {
+        let clearColorHex = NSColor(hex: "clearcolor")
+        let clear = NSColor.clear
+
+        XCTAssertFalse(clearColorHex.isEqual(to: clear))
+    }
+
+    func testRGBConvenience() {
+        XCTAssertTrue(NSColor(r: 0, g: 0, b: 0).isEqual(to: NSColor.black))
+        XCTAssertTrue(NSColor(r: 255, g: 255, b: 255).isEqual(to: NSColor.white))
+        XCTAssertTrue(NSColor(r: 0, g: 0, b: 0, a: 50).isEqual(to: NSColor.black.withAlphaComponent(0.5)))
+    }
+}


### PR DESCRIPTION
We're using Hex for styling an iOS app that we also want for OS X. 

- Modifying podspec to support OS X
- typealias for UI/NS-Color
- #if os(OS X) for imports and .RGB for OS X being pickier about color spaces